### PR TITLE
use veryShortWeekdaySymbols

### DIFF
--- a/Sources/ElegantCalendar/Helpers/Extensions/Calender+Dates.swift
+++ b/Sources/ElegantCalendar/Helpers/Extensions/Calender+Dates.swift
@@ -5,7 +5,7 @@ import SwiftUI
 extension Calendar {
     
     var dayOfWeekInitials: [String] {
-        weekdaySymbols.map { String($0.first!) }
+        veryShortWeekdaySymbols
     }
     
 }


### PR DESCRIPTION
use `weekdaySymbols.map { String($0.first!) }` will return a incorrect Symbol in other language, e.g. zh