### PR TITLE
Add possibility to configure title, text, and today text colors

### DIFF
--- a/Sources/ElegantCalendar/Helpers/Extensions/EnvironmentKey+CalendarTheme.swift
+++ b/Sources/ElegantCalendar/Helpers/Extensions/EnvironmentKey+CalendarTheme.swift
@@ -5,15 +5,18 @@ import SwiftUI
 public struct CalendarTheme: Equatable, Hashable {
 
     public let primary: Color
-    public let todayColor: Color
+    public let titleColor: Color
+    public let textColor: Color
+    public let todayTextColor: Color
+    public let todayBackgroundColor: Color
 
-    public init(primary: Color, todayColor: Color? = nil) {
+    public init(primary: Color, titleColor: Color? = nil, textColor: Color? = nil, todayTextColor: Color? = nil, todayBackgroundColor: Color? = nil) {
         self.primary = primary
-        if let todayColor = todayColor {
-            self.todayColor = todayColor
-        } else {
-            self.todayColor = primary
-        }
+
+        if let titleColor = titleColor { self.titleColor = titleColor } else { self.titleColor = primary }
+        if let textColor = textColor { self.textColor = textColor } else { self.textColor = .primary }
+        if let todayTextColor = todayTextColor { self.todayTextColor = todayTextColor } else { self.todayTextColor = primary }
+        if let todayBackgroundColor = todayBackgroundColor { self.todayBackgroundColor = todayBackgroundColor } else { self.todayBackgroundColor = .primary }
     }
 
 }

--- a/Sources/ElegantCalendar/Views/Monthly/DayView.swift
+++ b/Sources/ElegantCalendar/Views/Monthly/DayView.swift
@@ -54,16 +54,16 @@ struct DayView: View, MonthlyCalendarManagerDirectAccess {
 
     private var foregroundColor: Color {
         if isDayToday {
-            return theme.primary
+            return theme.todayTextColor
         } else {
-            return .primary
+            return theme.textColor
         }
     }
 
     private var backgroundColor: some View {
         Group {
             if isDayToday {
-                theme.todayColor
+                theme.todayBackgroundColor
             } else if isDaySelectableAndInRange {
                 theme.primary
                     .opacity(datasource?.calendar(backgroundColorOpacityForDate: day) ?? 1)

--- a/Sources/ElegantCalendar/Views/Monthly/MonthView.swift
+++ b/Sources/ElegantCalendar/Views/Monthly/MonthView.swift
@@ -59,14 +59,14 @@ private extension MonthView {
             .font(.system(size: 26))
             .bold()
             .tracking(7)
-            .foregroundColor(isWithinSameMonthAndYearAsToday ? theme.primary : .primary)
+            .foregroundColor(isWithinSameMonthAndYearAsToday ? theme.titleColor : .primary)
     }
 
     var yearText: some View {
         Text(month.year)
             .font(.system(size: 12))
             .tracking(2)
-            .foregroundColor(isWithinSameMonthAndYearAsToday ? theme.primary : .gray)
+            .foregroundColor(isWithinSameMonthAndYearAsToday ? theme.titleColor : .gray)
             .opacity(0.95)
     }
 


### PR DESCRIPTION
Hi, I needed to add more colors to keep calendar in harmony with other colors used in my app. Thus believing this might come handy for other users as well, I have added more options to configure colors using CalendarTheme.

P.S. The new changes will not break the code of old users if they decide to update to a new version.
I would be glad if you added new options to README as I didn't know where to quite fit this.  And if you approve changes would you be kind to release a new version? 

Thanks.